### PR TITLE
Enable deterministic numba cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,12 @@ Otherwise create a new environment:
 
         pip install --no-deps -e .
 
+## Numba caching
+
+Setting the environment variable `DATASHADER_NUMBA_CACHE=1` enables caching of
+Numba compiled kernels. When enabled, subsequent runs can load cached kernels
+from disk for faster startup.
+
 ## Learning more
 
 After working through the examples, you can find additional resources linked

--- a/datashader/compiler.py
+++ b/datashader/compiler.py
@@ -245,6 +245,8 @@ def make_antialias_stage_2_functions(antialias_stage_2, bases, cuda, partitioned
     logger.debug(code)
     exec(code, namespace)
     aa_stage_2_accumulate = ngjit(namespace["aa_stage_2_accumulate"])
+    aa_stage_2_accumulate.__name__ = "aa_stage_2_accumulate"
+    aa_stage_2_accumulate.__module__ = __name__
 
     # aa_stage_2_clear
     if np.any(np.isnan(aa_zeroes)):
@@ -257,6 +259,8 @@ def make_antialias_stage_2_functions(antialias_stage_2, bases, cuda, partitioned
     logger.debug(code)
     exec(code, namespace)
     aa_stage_2_clear = ngjit(namespace["aa_stage_2_clear"])
+    aa_stage_2_clear.__name__ = "aa_stage_2_clear"
+    aa_stage_2_clear.__module__ = __name__
 
     # aa_stage_2_copy_back
     @ngjit
@@ -264,6 +268,9 @@ def make_antialias_stage_2_functions(antialias_stage_2, bases, cuda, partitioned
         # Numba access to heterogeneous tuples is only permitted using literal_unroll.
         for agg_and_copy in literal_unroll(aggs_and_copies):
             agg_and_copy[0][:] = agg_and_copy[1][:]
+
+    aa_stage_2_copy_back.__name__ = "aa_stage_2_copy_back"
+    aa_stage_2_copy_back.__module__ = __name__
 
     return aa_stage_2_accumulate, aa_stage_2_clear, aa_stage_2_copy_back
 

--- a/datashader/cre_cache.py
+++ b/datashader/cre_cache.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import hashlib
+from numba.core.caching import Cache, _UserProvidedCacheLocator, CompileResultCacheImpl
+from numba.core.serialize import dumps
+from numba.core.dispatcher import Dispatcher
+from numba.extending import _Intrinsic
+
+
+class _PreciseCacheLocator(_UserProvidedCacheLocator):
+    """Cache locator hashing function bytecode and referenced globals."""
+
+    def __init__(self, py_func, py_file):
+        super().__init__(py_func, py_file)
+        self._py_func = py_func
+
+        code = py_func.__code__
+        glbs = py_func.__globals__
+
+        used_globals = {}
+        for k in code.co_names:
+            if k not in glbs:
+                continue
+            v = glbs[k]
+            if isinstance(v, _Intrinsic):
+                v_code = v._defn.__code__.co_code
+                used_globals[k] = v_code
+            elif isinstance(v, Dispatcher):
+                v_code = v.py_func.__code__.co_code
+                used_globals[k] = v_code
+            else:
+                used_globals[k] = v
+
+        func_bytes = code.co_code + dumps(used_globals)
+        self._func_hash = hashlib.sha256(func_bytes).hexdigest()
+
+    def get_source_stamp(self):
+        return self._func_hash
+
+    def get_disambiguator(self):
+        return self._func_hash[:10]
+
+    @classmethod
+    def from_function(cls, py_func, py_file):
+        return cls(py_func, py_file)
+
+
+class PreciseCacheImpl(CompileResultCacheImpl):
+    _locator_classes = [_PreciseCacheLocator, *CompileResultCacheImpl._locator_classes]
+
+
+class PreciseCache(Cache):
+    """Cache that saves and loads CompileResult objects using precise hashing."""
+
+    _impl_class = PreciseCacheImpl
+
+
+def enable_precise_caching(self):
+    """Enable caching using :class:`PreciseCache` on a Dispatcher."""
+
+    self._cache = PreciseCache(self.py_func)
+
+
+# Expose method on Dispatcher
+Dispatcher.enable_precise_caching = enable_precise_caching

--- a/datashader/glyphs/line.py
+++ b/datashader/glyphs/line.py
@@ -1090,10 +1090,28 @@ def _build_draw_segment(append, map_onto_pixel, expand_aggs_and_cols, line_width
                                 segment_start, segment_end, xm_2, ym_2, append,
                                 nx, ny, buffer, *aggs_and_cols)
             else:
-                _bresenham(i, sx, tx, sy, ty, xmin, xmax, ymin, ymax,
-                           segment_start, x0_2, x1_2, y0_2, y1_2,
-                           clipped, append, *aggs_and_cols)
+                _bresenham(
+                    i,
+                    sx,
+                    tx,
+                    sy,
+                    ty,
+                    xmin,
+                    xmax,
+                    ymin,
+                    ymax,
+                    segment_start,
+                    x0_2,
+                    x1_2,
+                    y0_2,
+                    y1_2,
+                    clipped,
+                    append,
+                    *aggs_and_cols,
+                )
 
+    draw_segment.__name__ = "draw_segment"
+    draw_segment.__module__ = __name__
     return draw_segment
 
 def _build_extend_line_axis0(draw_segment, expand_aggs_and_cols, antialias_stage_2_funcs):

--- a/datashader/glyphs/polygon.py
+++ b/datashader/glyphs/polygon.py
@@ -233,6 +233,8 @@ def _build_draw_polygon(append, map_onto_pixel, x_mapper, y_mapper, expand_aggs_
                     # If winding number is not zero, point
                     # is inside polygon
                     append(i, xi, yi, *aggs_and_cols)
+    draw_polygon.__name__ = "draw_polygon"
+    draw_polygon.__module__ = __name__
 
     return draw_polygon
 

--- a/datashader/utils.py
+++ b/datashader/utils.py
@@ -6,6 +6,9 @@ import re
 from inspect import getmro
 
 import numba as nb
+
+# Patches Dispatcher with enable_precise_caching
+import datashader.cre_cache  # noqa: F401
 import numpy as np
 import pandas as pd
 
@@ -43,14 +46,46 @@ except ImportError:
 class VisibleDeprecationWarning(UserWarning):
     """Visible deprecation warning.
 
-    By default, python will not show deprecation warnings, so this class
-    can be used when a very visible warning is helpful, for example because
-    the usage is most likely a user bug.
+    By default, python will not show deprecation warnings, so this class can be
+    used when a very visible warning is helpful, for example because the usage
+    is most likely a user bug.
     """
 
 
-ngjit = nb.jit(nopython=True, nogil=True)
-ngjit_parallel = nb.jit(nopython=True, nogil=True, parallel=True)
+ENABLE_NUMBA_CACHE = os.environ.get("DATASHADER_NUMBA_CACHE", "0").lower() not in (
+    "0",
+    "false",
+    "off",
+    "",
+)
+
+
+def _make_ngjit(parallel: bool = False):
+    jit_kwargs = {
+        "nopython": True,
+        "nogil": True,
+        # Disable Numba's default caching; we enable deterministic caching
+        # explicitly after compilation if requested.
+        "cache": False,
+    }
+    if parallel:
+        jit_kwargs["parallel"] = True
+    nb_jit = nb.jit(**jit_kwargs)
+
+    def wrapper(func):
+        compiled = nb_jit(func)
+        if ENABLE_NUMBA_CACHE and hasattr(compiled, "enable_precise_caching"):
+            try:
+                compiled.enable_precise_caching()
+            except Exception:
+                pass
+        return compiled
+
+    return wrapper
+
+
+ngjit = _make_ngjit()
+ngjit_parallel = _make_ngjit(parallel=True)
 
 # Get and save the Numba version, will be used to limit functionality
 numba_version = tuple([int(x) for x in re.match(


### PR DESCRIPTION
## Summary
- add precise Numba caching implementation based on CRE
- wrap numba jits with caching support in utils
- give nested jit functions stable names for caching
- document `DATASHADER_NUMBA_CACHE` env var
- fix precise caching integration

## Testing
- `pre-commit run --files README.md datashader/glyphs/line.py datashader/glyphs/polygon.py datashader/utils.py datashader/cre_cache.py datashader/compiler.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'param')*

------
https://chatgpt.com/codex/tasks/task_e_686772a269188332bd27c674207b4200