### PR TITLE
Fix numba cache pickling issue

### DIFF
--- a/datashader/cre_cache.py
+++ b/datashader/cre_cache.py
@@ -29,6 +29,13 @@ class _PreciseCacheLocator(_UserProvidedCacheLocator):
                 v_code = v.py_func.__code__.co_code
                 used_globals[k] = v_code
             else:
+                try:
+                    # Ensure the global is picklable, otherwise skip it to
+                    # avoid failures during caching (e.g. builtins.input in
+                    # interactive environments)
+                    dumps(v)
+                except Exception:
+                    continue
                 used_globals[k] = v
 
         func_bytes = code.co_code + dumps(used_globals)


### PR DESCRIPTION
## Summary
- handle non-picklable globals in numba caching to avoid PicklingError

## Testing
- `pytest datashader/tests/test_pandas.py::test_line_antialias_nan -q` *(fails: NumbaWarning: Cannot cache compiled function)*
- `python - <<'EOF'
import pandas as pd
import numpy as np
import datashader as ds
print('ENABLE_NUMBA_CACHE', ds.utils.ENABLE_NUMBA_CACHE)
x = np.linspace(0, 10, 100)
y = np.sin(x)
df = pd.DataFrame({'x': x, 'y': y})
cvs = ds.Canvas(plot_width=100, plot_height=100)
agg = cvs.line(df, x='x', y='y')
print('agg shape', agg.shape)
EOF`

------
https://chatgpt.com/codex/tasks/task_e_686b7927b58883328f39f5d7ea3b421a