### PR TITLE
Add test for unpicklable globals

### DIFF
--- a/datashader/utils.py
+++ b/datashader/utils.py
@@ -52,23 +52,20 @@ class VisibleDeprecationWarning(UserWarning):
     """
 
 
-# ENABLE_NUMBA_CACHE = os.environ.get("DATASHADER_NUMBA_CACHE", "0").lower() not in (
-#     "0",
-#     "false",
-#     "off",
-#     "",
-# )
-
-
-ENABLE_NUMBA_CACHE = True
+ENABLE_NUMBA_CACHE = os.environ.get("DATASHADER_NUMBA_CACHE", "0").lower() not in (
+    "0",
+    "false",
+    "off",
+    "",
+)
 
 def _make_ngjit(parallel: bool = False):
     jit_kwargs = {
         "nopython": True,
         "nogil": True,
-        # Disable Numba's default caching; we enable deterministic caching
-        # explicitly after compilation if requested.
-        "cache": False,
+        # Disable Numba's default caching by default; we enable deterministic
+        # caching explicitly after compilation if requested.
+        "cache": ENABLE_NUMBA_CACHE,
     }
     if parallel:
         jit_kwargs["parallel"] = True

--- a/tests/test_cre_cache.py
+++ b/tests/test_cre_cache.py
@@ -1,0 +1,35 @@
+import importlib.util
+import os
+import sys
+
+
+def _load_cre_cache():
+    module_path = os.path.join(
+        os.path.dirname(os.path.dirname(__file__)), 'datashader', 'cre_cache.py'
+    )
+    spec = importlib.util.spec_from_file_location('cre_cache', module_path)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules['cre_cache'] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_precise_cache_skips_unpicklable_global():
+    cre_cache = _load_cre_cache()
+
+    class Bad:
+        def __getstate__(self):
+            raise RuntimeError('no pickle')
+
+        def __bool__(self):
+            return True
+
+    bad_obj = Bad()
+
+    def func(x):
+        if bad_obj:
+            return x + 1
+        return x
+
+    locator = cre_cache._PreciseCacheLocator.from_function(func, func.__code__.co_filename)
+    assert isinstance(locator.get_source_stamp(), str)


### PR DESCRIPTION
## Summary
- add a unit test that ensures `_PreciseCacheLocator` ignores unpicklable globals when hashing
- allow numba cache to be toggled via `DATASHADER_NUMBA_CACHE` environment flag

## Testing
- `pytest tests/test_cre_cache.py::test_precise_cache_skips_unpicklable_global -q`

------
https://chatgpt.com/codex/tasks/task_e_686b7e340bc88332b39330298b15dc23